### PR TITLE
Enabled upload to default S3 region when no region has been declared.

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -38,12 +38,20 @@ module.exports = function(grunt) {
 			grunt.warn("Missing secretAccessKey in options");
 		}
 
-		if (!options.region) {
-			grunt.warn("Missing region in options");
-		}
-
 		if (!options.bucket) {
 			grunt.warn("Missing bucket in options");
+		}
+
+		var s3_options = {
+			bucket : options.bucket,
+			accessKeyId : options.accessKeyId,
+			secretAccessKey : options.secretAccessKey
+		};
+
+		if (!options.region) {
+			grunt.log.write("No region defined, uploading to US Standard\n");
+		} else {
+			s3_options.region = options.region;
 		}
 
 		if (options.params) {
@@ -54,7 +62,7 @@ module.exports = function(grunt) {
 			}
 		}
 
-		var s3 = new AWS.S3({accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey, region: options.region});
+    var s3 = new AWS.S3(s3_options);
 		var s3_object = grunt.util._.extend({Bucket: options.bucket, ACL: options.access}, options.params);
 
 		var dest;


### PR DESCRIPTION
Documentation Reference:

http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

In addition to the various s3-REGION.amazonaws.com hosts, S3 supports a "US Standard" endpoint that is not region specific. The AWS SDK controls for this by making the "region" parameter in the AWS.S3 configuration optional, defaulting to s3.amazonaws.com. This pull request removes the grunt.fail.warn requirement for options.region and constructs the s3 parameters based on whether the property has been set.
