### PR TITLE
Recursively listObjects based on IsTruncated field Fixes #10

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -172,7 +172,6 @@ module.exports = function (grunt) {
 
 							// '.' means that no dest path has been given (root). Nothing to create there.
 							if (dest !== '.') {
-
 								uploads.push({
 									src: src, 
 									dest: dest, 
@@ -209,8 +208,9 @@ module.exports = function (grunt) {
 
 					var objects = (contents) ? contents.concat(list.Contents) : list.Contents;
 
-					if (list.Marker) {
-						listObjects(prefix, callback, list.Marker, objects);
+					if (list.IsTruncated) {
+						var marker = list.Contents.slice(-1)[0].Key;
+						listObjects(prefix, callback, marker, objects);
 					}
 					else {
 						callback(_.uniq(objects, function (o) { return o.Key; }));


### PR DESCRIPTION
Based on this stackoverflow article:
http://stackoverflow.com/questions/9437581/node-js-amazon-s3-how-to-iterate-through-all-files-in-a-bucket, it seems that checking `IsTruncated` is the more reliable way of determining that there is more content.
