### PR TITLE
Changing uploading of files to use ReadStream instead of Buffer, to avoid memory issues with large files

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -416,11 +416,12 @@ module.exports = function (grunt) {
 				var upload_queue = async.queue(function (object, uploadCallback) {
 
 					var server_file = _.where(objects, { Key: object.dest })[0];
-					var buffer = grunt.file.read(object.src, { encoding: null });
+					var stream = fs.createReadStream(object.src);
 
 					if (server_file && object.differential) {
+						var hash_buffer = grunt.file.read(object.src, { encoding: null });
 						// S3's ETag has quotes around it...
-						var md5_hash = '"' + crypto.createHash('md5').update(buffer).digest('hex') + '"';
+						var md5_hash = '"' + crypto.createHash('md5').update(hash_buffer).digest('hex') + '"';
 						object.need_upload = md5_hash !== server_file.ETag;
 					}
 
@@ -429,7 +430,7 @@ module.exports = function (grunt) {
 						var type = options.mime[object.src] || object.params.ContentType || mime.lookup(object.src);
 						var upload = _.defaults({
 							ContentType: type,
-							Body: buffer,
+							Body: stream,
 							Key: object.dest,
 							Bucket: options.bucket,
 							ACL: options.access


### PR DESCRIPTION
This is a sort of, works for me, pull request.

When trying to upload large files grunt was hitting the memory limits on the small server it was running on and being killed. The commit changes the upload code from using a Buffer to a ReadStream, which should keep the memory usage steady.

However, I am not using the hash creation code, so my changes there are just to keep it working as it was before. It could also be improved by following this SO answer: [#18658613](http://stackoverflow.com/a/18658613)
