### PR TITLE
New option: only show files changed in differential upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ In order to be able to compare to the local file names, it is necessary for `des
   {cwd: 'dist/scripts/', dest: 'scripts/', 'action': 'download', differential: true}
 ```
 
-#### options.diffChangesOnly
+#### options.displayChangesOnly
 Type: `Boolean`
 Default: `false`
 

--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
 			mock: false,
 			differential: false,
 			stream: false,
-			diffChangesOnly: false
+			displayChangesOnly: false
 		});
 
 		// To deprecate
@@ -729,7 +729,7 @@ module.exports = function (grunt) {
 							uploaded++;
 							grunt.log.writeln('- ' + file.src.cyan + ' -> ' + (object_url + file.dest).cyan);
 						}
-						else if (!options.diffChangesOnly) {
+						else if (!options.displayChangesOnly) {
 							grunt.log.writeln('- ' + file.src.yellow + ' === ' + (object_url + file.dest).yellow);
 						}
 					});


### PR DESCRIPTION
I added a new option, `diffChangesOnly`, that will prevent unchanged files from being logged when performing a differential upload. I'm not sure if the option name is the greatest, but I didn't want too long of a name either. Feel free to suggest a better one :)

This will close #22.
