### PR TITLE
Support the use of IAM credentials.

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -167,14 +167,6 @@ module.exports = function (grunt) {
 			});
 		};
 
-		if (!options.accessKeyId && !options.mock) {
-			grunt.warn("Missing accessKeyId in options");
-		}
-
-		if (!options.secretAccessKey && !options.mock) {
-			grunt.warn("Missing secretAccessKey in options");
-		}
-
 		if (!options.bucket) {
 			grunt.warn("Missing bucket in options");
 		}


### PR DESCRIPTION
When using IAM credentials provided by an EC2 instance, there is no need to explicitly set the `accessKeyId` and `secretAccessKey` properties.

I have tested this on an EC2 instance with IAM access to an S3 bucket. The upload is successful as expected.
