### PR TITLE
Allow user to config signatureVersion.

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -190,7 +190,7 @@ module.exports = function (grunt) {
 		}
 
 		// Allow additional (not required) options
-		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions']));
+		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions', 'signatureVersion']));
 
 		var s3 = new AWS.S3(s3_options);
 


### PR DESCRIPTION
`signatureVersion` must be `v4` in Beijing Region, not the default value `v2` of Global Region, so user have to set this param explicit.
