### PR TITLE
Supporting a session Token

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
 			access: 'public-read',
 			accessKeyId: process.env.AWS_ACCESS_KEY_ID,
 			secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+            sessionToken: process.env.AWS_SECURITY_TOKEN,
 			uploadConcurrency: 1,
 			downloadConcurrency: 1,
 			mime: {},
@@ -181,7 +182,8 @@ module.exports = function (grunt) {
 		var s3_options = {
 			bucket: options.bucket,
 			accessKeyId: options.accessKeyId,
-			secretAccessKey: options.secretAccessKey
+			secretAccessKey: options.secretAccessKey,
+            sessionToken: options.sessionToken
 		};
 
 		if (!options.region) {


### PR DESCRIPTION
The environment in which i'm uploading to requires a sessionToken to be supplied, simply adding the following options was enough for me to upload to the designated s3 bucket. I'm not sure if we need to guard against a sessionToken not being provided.
Also the error message that the sdk spits back without this change is the following:
InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.
which was a bit misleading
