### PR TITLE
Create proper Content-type header with charset

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "aws-sdk": "2.0.x",
-    "mime": "1.2.x",
+    "mime-types": "2.0.x",
     "lodash": "2.4.x",
     "async": "0.9.x",
     "progress": "1.1.x"

--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -12,7 +12,7 @@ var path = require('path');
 var fs = require('fs');
 var crypto = require('crypto');
 var AWS = require('aws-sdk');
-var mime = require('mime');
+var mime = require('mime-types');
 var _ = require('lodash');
 var async = require('async');
 var Progress = require('progress');
@@ -569,7 +569,7 @@ module.exports = function (grunt) {
 
 			if (object.need_upload && !options.debug) {
 
-				var type = options.mime[object.src] || object.params.ContentType || mime.lookup(object.src);
+				var type = options.mime[object.src] || object.params.ContentType || mime.contentType(object.src);
 				var upload = _.defaults({
 					ContentType: type,
 					Key: object.dest,


### PR DESCRIPTION
This commit migrates from npm mime to the seemingly better maintained
mime-types. This allows replacing the mime.lookup call by mime.contentType

This is moderately important for javascript files which are otherwhise updloaded
with a Content-type header without charset information possibly leading to
incorrect decoding by browsers (see https://github.com/ariya/phantomjs/issues/12867)