### PR TITLE
Fix mime-type method to get file type

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -569,7 +569,7 @@ module.exports = function (grunt) {
 
 			if (object.need_upload && !options.debug) {
 
-				var type = options.mime[object.src] || object.params.ContentType || mime.contentType(object.src);
+				var type = options.mime[object.src] || object.params.ContentType || mime.lookup(object.src);
 				var upload = _.defaults({
 					ContentType: type,
 					Key: object.dest,


### PR DESCRIPTION
mime.contentType is used to generate a full content-type header from a partial type.
mime.lookup is used to get the content-type of files
https://github.com/jshttp/mime-types#mimelookuppath