### PR TITLE
Support copying files with special characters

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -458,7 +458,7 @@ module.exports = function (grunt) {
 				callback(null, false);
 			}
 			else {
-				s3.copyObject({ Key: object.dest, CopySource: encodeURI(options.bucket + '/' + object.Key), Bucket: options.bucket }, function (err, data) {
+				s3.copyObject({ Key: object.dest, CopySource: encodeURIComponent(options.bucket + '/' + object.Key), Bucket: options.bucket }, function (err, data) {
 					if (err) {
 						callback(err);
 					}


### PR DESCRIPTION
While copying objects works for most files, files with special characters like '+' are unable to be copied due to encodeURI ignoring special characters and the S3 SDK then replies with the error code 'NoSuchKey' as the CopySource key requires all characters to be encoded. 