### PR TITLE
adding `uniqueDest` option to check dest doesn't exist before uploading

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -796,22 +796,44 @@ module.exports = function (grunt) {
 				unique_dests = [''];
 			}
 
-			if (unique_dests.length) {
-				async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
-					listObjects(dest, function(objects) {
-						callback(null, objects);
-					});
-				}, function (err, objects) {
-					if (err) {
-						callback(err)
-					} else {
-						var server_files = Array.prototype.concat.apply([], objects);
-						startUploads(server_files);
-					}
-				});
-			} else {
-				startUploads([]);
-			}
+			// make sure of unique destination by
+      // checking the first file.
+      var first = task.files[0];
+      if (first && first.orig && first.orig.uniqueDest) {
+          var dest = first.orig.dest;
+          s3.listObjects({ Prefix: dest, Bucket: options.bucket }, function (err, data) {
+                if (err) {
+                    grunt.fatal('Checking uniqueDest failed\n' + err);
+                    return;
+                }
+              if (data.Contents.length) {
+                  grunt.fatal('destination already exists on s3: ' + dest);
+              } else {
+                  continueUpload()
+              }
+          });
+      } else {
+          continueUpload();
+      }
+
+      function continueUpload(){
+          if (unique_dests.length) {
+              async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
+                  listObjects(dest, function(objects) {
+                      callback(null, objects);
+                  });
+              }, function (err, objects) {
+                  if (err) {
+                      callback(err)
+                  } else {
+                      var server_files = Array.prototype.concat.apply([], objects);
+                      startUploads(server_files);
+                  }
+              });
+          } else {
+              startUploads([]);
+          }
+      }
 		};
 
 		var queue = async.queue(function (task, callback) {

--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -800,39 +800,39 @@ module.exports = function (grunt) {
 			// checking the first file.
 			var first = task.files[0];
 			if (first && first.orig && first.orig.uniqueDest) {
-					var dest = first.orig.dest;
-					s3.listObjects({ Prefix: dest, Bucket: options.bucket }, function (err, data) {
-								if (err) {
-										grunt.fatal('Checking uniqueDest failed\n' + err);
-										return;
-								}
-							if (data.Contents.length) {
-									grunt.fatal('destination already exists on s3: ' + dest);
-							} else {
-									continueUpload()
-							}
-					});
+				var dest = first.orig.dest;
+				s3.listObjects({ Prefix: dest, Bucket: options.bucket }, function (err, data) {
+					if (err) {
+						grunt.fatal('Checking uniqueDest failed\n' + err);
+						return;
+					}
+					if (data.Contents.length) {
+						grunt.fatal('destination already exists on s3: ' + dest);
+					} else {
+						continueUpload()
+					}
+				});
 			} else {
-					continueUpload();
+				continueUpload();
 			}
 
 			function continueUpload(){
-					if (unique_dests.length) {
-							async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
-									listObjects(dest, function(objects) {
-											callback(null, objects);
-									});
-							}, function (err, objects) {
-									if (err) {
-											callback(err)
-									} else {
-											var server_files = Array.prototype.concat.apply([], objects);
-											startUploads(server_files);
-									}
-							});
-					} else {
-							startUploads([]);
-					}
+				if (unique_dests.length) {
+					async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
+						listObjects(dest, function(objects) {
+							callback(null, objects);
+						});
+					}, function (err, objects) {
+						if (err) {
+							callback(err)
+						} else {
+							var server_files = Array.prototype.concat.apply([], objects);
+							startUploads(server_files);
+						}
+					});
+				} else {
+					startUploads([]);
+				}
 			}
 		};
 

--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -797,43 +797,43 @@ module.exports = function (grunt) {
 			}
 
 			// make sure of unique destination by
-      // checking the first file.
-      var first = task.files[0];
-      if (first && first.orig && first.orig.uniqueDest) {
-          var dest = first.orig.dest;
-          s3.listObjects({ Prefix: dest, Bucket: options.bucket }, function (err, data) {
-                if (err) {
-                    grunt.fatal('Checking uniqueDest failed\n' + err);
-                    return;
-                }
-              if (data.Contents.length) {
-                  grunt.fatal('destination already exists on s3: ' + dest);
-              } else {
-                  continueUpload()
-              }
-          });
-      } else {
-          continueUpload();
-      }
+			// checking the first file.
+			var first = task.files[0];
+			if (first && first.orig && first.orig.uniqueDest) {
+					var dest = first.orig.dest;
+					s3.listObjects({ Prefix: dest, Bucket: options.bucket }, function (err, data) {
+								if (err) {
+										grunt.fatal('Checking uniqueDest failed\n' + err);
+										return;
+								}
+							if (data.Contents.length) {
+									grunt.fatal('destination already exists on s3: ' + dest);
+							} else {
+									continueUpload()
+							}
+					});
+			} else {
+					continueUpload();
+			}
 
-      function continueUpload(){
-          if (unique_dests.length) {
-              async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
-                  listObjects(dest, function(objects) {
-                      callback(null, objects);
-                  });
-              }, function (err, objects) {
-                  if (err) {
-                      callback(err)
-                  } else {
-                      var server_files = Array.prototype.concat.apply([], objects);
-                      startUploads(server_files);
-                  }
-              });
-          } else {
-              startUploads([]);
-          }
-      }
+			function continueUpload(){
+					if (unique_dests.length) {
+							async.mapLimit(unique_dests, options.uploadConcurrency, function (dest, callback) {
+									listObjects(dest, function(objects) {
+											callback(null, objects);
+									});
+							}, function (err, objects) {
+									if (err) {
+											callback(err)
+									} else {
+											var server_files = Array.prototype.concat.apply([], objects);
+											startUploads(server_files);
+									}
+							});
+					} else {
+							startUploads([]);
+					}
+			}
 		};
 
 		var queue = async.queue(function (task, callback) {


### PR DESCRIPTION
This pull request adds the `uniqueDest` option on the file, which prevents the upload if the destination has files uploaded already.

We required a fool proof way of stopping developers from overwriting previous deployed versions of assets. We are pulling the version from our `package.json`  and using that in our `dest` path. If they tried to run the aws-s3 task without updating this version, we wanted the upload to fail.

```js
aws_s3: {
  options: {
    accessKeyId: '<%= aws.id %>',
    secretAccessKey: '<%= aws.key %>',
    region: 'eu-west-1',
    bucket: 'foo'
  },
  production: {
    files: [{ 
        expand: true,
        cwd: 'build',
        src: ['**'],
        uniqueDest: true,
        dest: 'builds/<%= pkg.version %>/'
    }]
  }
}
```

I couldn't get the test suite to run, and by the looks of it neither could travis, so I didn't look much further into writing tests.

We would love the feature to exist, the way I've done it may not be the best, so feel free to let me know if you want it changed before accepting.
