### PR TITLE
Add options.access as ACL for the copy action.

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -462,7 +462,7 @@ module.exports = function (grunt) {
 				callback(null, false);
 			}
 			else {
-				s3.copyObject({ Key: object.dest, CopySource: encodeURIComponent(options.bucket + '/' + object.Key), Bucket: options.bucket }, function (err, data) {
+				s3.copyObject({ Key: object.dest, CopySource: encodeURIComponent(options.bucket + '/' + object.Key), Bucket: options.bucket, ACL: options.access }, function (err, data) {
 					if (err) {
 						callback(err);
 					}


### PR DESCRIPTION
Include the ACL when copying S3 objects. Fix for #70.