### PR TITLE
Feature/s3 force path style

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Type: `String`
 
 The AWS endpoint you'd like to use. Set by default by the region.
 
+#### options.s3ForcePathStyle
+Type: `Boolean`
+Default: `false`
+
+Force use path-style url (http://endpoint/bucket/path) instead of default host-style (http://bucket.endpoint/path)
+
 #### options.region
 Type: `String`  
 Default: `US Standard`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Type: `String`
 The AWS endpoint you'd like to use. Set by default by the region.
 
 #### options.s3ForcePathStyle
-Type: `Boolean`
+Type: `Boolean`  
 Default: `false`
 
 Force use path-style url (http://endpoint/bucket/path) instead of default host-style (http://bucket.endpoint/path)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-aws-s3",
   "description": "Interact with AWS S3 using the AWS SDK",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "homepage": "https://github.com/MathieuLoutre/grunt-aws-s3",
   "author": {
     "name": "Mathieu Triay",

--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -210,7 +210,7 @@ module.exports = function (grunt) {
 		}
 
 		// Allow additional (not required) options
-		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions', 'signatureVersion']));
+		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions', 'signatureVersion', 's3ForcePathStyle']));
 
 		var s3 = new AWS.S3(s3_options);
 


### PR DESCRIPTION
This plugin can be also used for other S3-compatible services than AWS. But some of them do not support host-style buckets (bucket.endpoint.com). aws-sdk module allows to force use path-style bucket via `s3ForcePathStyle` option. So just please expose it to the user. 