### PR TITLE
Replace contains (which is depracated in lodash 4) with includes

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -82,7 +82,7 @@ module.exports = function (grunt) {
 		var isValidParams = function (params) {
 
 			return _.every(_.keys(params), function (key) {
-				return _.contains(put_params, key);
+				return _.includes(put_params, key);
 			});
 		};
 


### PR DESCRIPTION
Lodash 4 removed _.contains in favor of _.includes and the usage of _.contains causes the package to exit with an error.